### PR TITLE
Adicionando padding ao dia da data

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ description: "No mês de Março o CocoaHeads Brasil irá trazer 20 artigos de vo
         </h3>
         {% endif %}
     </a>
-    <p class="post-meta">Postado por {% if post.author %}{{ post.author }}{% else %}{{ site.title }}{% endif %} em {{ post.date | date: "%-d/%m/%Y" }}</p>
+    <p class="post-meta">Postado por {% if post.author %}{{ post.author }}{% else %}{{ site.title }}{% endif %} em {{ post.date | date: "%d/%m/%Y" }}</p>
 </div>
 <hr>
 {% endfor %}


### PR DESCRIPTION
Atualmente a data está sendo publicada com padding de zero no mês, porém não no dia. Isso causa resultados como 3/03/2017, que em minha opinião(e em mais algumas), parece estranho.