### PR TITLE
Padronizando formato de data com dia com padding

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ header-img: img/home-bg.jpg
 email: contato@cocoaheads.com.br
 copyright_name: CocoaHeads Brasil
 description: "20 artigos de voluntários durante o mês de Março para comemorar o equinociOS"
+date_format: "%d/%m/%Y"
 url: "http://equinocios.com"
 twitter_username: cocoaheadsbr
 github_username:  CocoaHeadsBrasil

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,7 +14,7 @@ comments: true
                         {% if page.subtitle %}
                         <h2 class="subheading">{{ page.subtitle }}</h2>
                         {% endif %}
-                        <span class="meta">Postado por {% if page.author %}{{ page.author }}{% else %}{{ site.title }}{% endif %} em {{ page.date | date: "%-d/%m/%Y" }}</span>
+                        <span class="meta">Postado por {% if page.author %}{{ page.author }}{% else %}{{ site.title }}{% endif %} em {{ page.date | date: site.date_format }}</span>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ description: "No mês de Março o CocoaHeads Brasil irá trazer 20 artigos de vo
         </h3>
         {% endif %}
     </a>
-    <p class="post-meta">Postado por {% if post.author %}{{ post.author }}{% else %}{{ site.title }}{% endif %} em {{ post.date | date: "%-d/%m/%Y" }}</p>
+    <p class="post-meta">Postado por {% if post.author %}{{ post.author }}{% else %}{{ site.title }}{% endif %} em {{ post.date | date: site.date_format }}</p>
 </div>
 <hr>
 {% endfor %}


### PR DESCRIPTION
Atualmente a data está sendo publicada com padding de zero no mês, porém não no dia. Isso causa resultados como 3/03/2017, que em minha opinião(e em mais algumas), parece estranho. Padronizei ela para ficar 03/03/2017, com o mês e dia com padding.